### PR TITLE
fix: enable localstack test

### DIFF
--- a/lib/lambda/footprint-app.ts
+++ b/lib/lambda/footprint-app.ts
@@ -4,7 +4,7 @@ const bodyParser = require('body-parser')
 import express from 'express'
 
 const TABLE_NAME = process.env.TABLE_NAME || ''
-const MOCK = process.env.LOCALSTACK_HOSTNAME === 'localhost' || false
+const MOCK = process.env.LOCALSTACK_HOSTNAME ? true : false
 
 const toComponent = (item: any) => {
   const dir_domain = item.dir_domain.split('_')
@@ -25,9 +25,9 @@ let dynamoParam = {}
 let tableName = TABLE_NAME
 
 if (MOCK) {
-  // for local mock
+  // for mock and localstack
   dynamoParam = {
-    endpoint: 'http://localhost:4566',
+    endpoint: `http://${process.env.LOCALSTACK_HOSTNAME}:4566`,
     region: 'ap-northeast-1',
     accessKeyId: 'testUser',
     secretAccessKey: 'testAccessKey'

--- a/lib/lambda/profile-app.ts
+++ b/lib/lambda/profile-app.ts
@@ -17,7 +17,7 @@ const FOOTPRINT_TABLE_NAME = process.env.FOOTPRINT_TABLE_NAME || ''
 const PARAMETER_TABLE_NAME = process.env.PARAMETER_TABLE_NAME || ''
 const PROFILE_TABLE_NAME = process.env.PROFILE_TABLE_NAME || ''
 const OPTION_TABLE_NAME = process.env.OPTION_TABLE_NAME || ''
-const MOCK = process.env.LOCALSTACK_HOSTNAME === 'localhost' || false
+const MOCK = process.env.LOCALSTACK_HOSTNAME ? true : false
 
 let dynamoParam = {}
 let footprintTableName = FOOTPRINT_TABLE_NAME
@@ -26,9 +26,9 @@ let profileTableName = PROFILE_TABLE_NAME
 let optionTableName = OPTION_TABLE_NAME
 
 if (MOCK) {
-  // for local mock
+  // for mock and localstack
   dynamoParam = {
-    endpoint: 'http://localhost:4566',
+    endpoint: `http://${process.env.LOCALSTACK_HOSTNAME}:4566`,
     region: 'ap-northeast-1',
     accessKeyId: 'testUser',
     secretAccessKey: 'testAccessKey'

--- a/lib/lambda/share-app.ts
+++ b/lib/lambda/share-app.ts
@@ -4,15 +4,15 @@ const bodyParser = require('body-parser')
 import express from 'express'
 
 const TABLE_NAME = process.env.TABLE_NAME || ''
-const MOCK = process.env.LOCALSTACK_HOSTNAME === 'localhost' || false
+const MOCK = process.env.LOCALSTACK_HOSTNAME ? true : false
 
 let dynamoParam = {}
 let tableName = TABLE_NAME
 
 if (MOCK) {
-  // for local mock
+  // for mock and localstack
   dynamoParam = {
-    endpoint: 'http://localhost:4566',
+    endpoint: `http://${process.env.LOCALSTACK_HOSTNAME}:4566`,
     region: 'ap-northeast-1',
     accessKeyId: 'testUser',
     secretAccessKey: 'testAccessKey'

--- a/src/tests/integration.test.ts
+++ b/src/tests/integration.test.ts
@@ -8,6 +8,8 @@ import app from '../../lib/lambda/profile-app' // テスト対象をインポー
 import footprintApp from '../../lib/lambda/footprint-app' // テスト対象をインポート
 import { createTestCases, TestCase } from './util'
 
+jest.setTimeout(10000)
+
 describe('Test all integrations', () => {
   const domains = ['housing', 'mobility', 'other', 'extra']
   // eslint-disable-next-line no-undef


### PR DESCRIPTION
@ayuki-joto 
localstack上のapi gateway→lambda→dynamodbのテストができるようになりました。環境変数REST_ENDPOINTにlocalstackのapi gatewayのurlを指定することでテストが動きます（テストに時間がかかるのでデフォルトのテストはdynamodbを直接参照するようにしています）。

lambdaの中で`localhost`としていたところを`LOCALSTACK_HOSTNAME`から値を取るようにしたら動くようになりました。